### PR TITLE
Use the Django 1.6 transaction management.

### DIFF
--- a/login_token/models.py
+++ b/login_token/models.py
@@ -57,7 +57,7 @@ class LoginToken(InstanceMixin, models.Model):
 #   https://code.djangoproject.com/ticket/16073
 #   https://code.djangoproject.com/ticket/6707
 
-@transaction.commit_on_success
+@transaction.atomic
 def handle_instance_users_change(*args, **kwargs):
     '''Keep login_token_logintoken and instances_instance_users in sync
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+Django==1.6.3
+
 -e git+https://github.com/mysociety/sayit#egg=django-sayit


### PR DESCRIPTION
In Django 1.6, transaction management changed, and commit_on_success
is now deprecated:

https://docs.djangoproject.com/en/dev/releases/1.6/#new-transaction-management-model

Replace our use of commit_on_success with atomic, and pin Django
to a version that works.
