### PR TITLE
SayIt doesn't recognize docTitle

### DIFF
--- a/sayit_mysociety_org/templates/about/developers.html
+++ b/sayit_mysociety_org/templates/about/developers.html
@@ -120,7 +120,7 @@ example showing the basic structure:
       &lt;/references&gt;
     &lt;/meta&gt;
     &lt;preface&gt;
-      &lt;docTitle&gt;The Tempest&lt;/docTitle&gt;
+      &lt;docDate date="1610-07-15"&gt;fifteenth day of July, sixteen hundred and ten&lt;/docDate&gt;
     &lt;/preface&gt;
     &lt;debateBody&gt;
       &hellip;
@@ -194,8 +194,7 @@ name of the overall content.
 <p>The <code>preface</code> element should contain <a href="#block">block</a>
 element children. Within that, you may use various inline elements to signify
 things such as the title, type, number, purpose, or jurisdiction of the
-document &ndash; SayIt currently only spots the <code>docDate</code> or
-<code>docTitle</code> elements.
+document &ndash; SayIt currently only spots the <code>docDate</code> element.
 
 <!--
     <docType|docTitle|docNumber|shortTitle|docPurpose|docIntroducer|docStage|docStatus|docJurisdiction|docketNumber>


### PR DESCRIPTION
Also updated AN example to use docDate.
