### PR TITLE
Support for Foundation "label" components

### DIFF
--- a/web/sass/_foundation.scss
+++ b/web/sass/_foundation.scss
@@ -36,7 +36,7 @@
 @import "foundation/components/alert-boxes";
 @import "foundation/components/breadcrumbs";
 // @import "foundation/components/keystrokes";
-// @import "foundation/components/labels";
+@import "foundation/components/labels";
 @import "foundation/components/inline-lists";
 // @import "foundation/components/pagination";
 // @import "foundation/components/panels";


### PR DESCRIPTION
https://github.com/mysociety/sayit/pull/273 includes Foundation label elements.

Since foundation imports aren't inherited from the django app, this pull request adds support for Foundation labels to the sayit.mysociety.org project.
