### PR TITLE
Use a slugify function that copes with Mandarin names

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,7 @@ beautifulsoup4
 requests_cache
 django-apptemplates==0.0.1
 
+# A slugify that deals with all-non-Latin characters:
+python-slugify==0.0.7
+
 -e git+https://github.com/mysociety/sayit#egg=django-sayit

--- a/sayit_mysociety_org/settings/base.py
+++ b/sayit_mysociety_org/settings/base.py
@@ -5,6 +5,7 @@ import os
 import sys
 from django.conf import global_settings
 from .paths import *
+from slugify import slugify
 
 # Get the changeable configuration
 from .mysociety import *
@@ -257,6 +258,8 @@ if DEBUG_TOOLBAR:
     DEBUG_TOOLBAR_PATCH_SETTINGS = False
     MIDDLEWARE_CLASSES.append( 'debug_toolbar.middleware.DebugToolbarMiddleware' )
     INSTALLED_APPS.append( 'debug_toolbar' )
+
+SLUGGABLE_SLUGIFY_FUNCTION = slugify
 
 # Allow local changes of settings
 try:

--- a/sayit_mysociety_org/tests.py
+++ b/sayit_mysociety_org/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 import urlparse
 
@@ -6,6 +8,8 @@ from django.contrib.auth import get_user_model
 
 from instances.tests import InstanceTestCase
 
+from speeches.models import Speaker, Section
+from instances.models import Instance
 
 class SmokeTests(InstanceTestCase):
     """Very basic tests to make sure we can see anything at all."""
@@ -103,3 +107,66 @@ class ShareInstanceTests(InstanceTestCase):
             'You have been invited to a SayIt',
             mail.outbox[0].subject,
             )
+
+class SlugTests(InstanceTestCase):
+
+    def test_all_latin_speaker_slug(self):
+        latin_speaker = Speaker.objects.create(
+            name='Foo Bar',
+            instance=self.instance
+        )
+        try:
+            self.assertEqual(
+                latin_speaker.slug,
+                'foo-bar'
+            )
+        finally:
+            latin_speaker.delete()
+
+    def test_all_cjk_speaker_slug(self):
+        cjk_speaker = Speaker.objects.create(
+            name=u'張家祝',
+            instance=self.instance
+        )
+        cjk_speaker_duplicate = Speaker.objects.create(
+            name=u'張家祝',
+            instance=self.instance
+        )
+        try:
+            self.assertEqual(
+                cjk_speaker.slug,
+                'zhang-jia-zhu'
+            )
+            self.assertEqual(
+                cjk_speaker_duplicate.slug,
+                'zhang-jia-zhu-2'
+            )
+        finally:
+            cjk_speaker.delete()
+            cjk_speaker_duplicate.delete()
+
+    def test_cyrillic_speaker_slug(self):
+        cyrillic_speaker = Speaker.objects.create(
+            name=u'борщ',
+            instance=self.instance
+        )
+        try:
+            self.assertEqual(
+                cyrillic_speaker.slug,
+                'borshch'
+            )
+        finally:
+            cyrillic_speaker.delete()
+
+    def test_all_cjk_section_slug(self):
+        cjk_section = Section.objects.create(
+            heading=u'經貿國是會議全國大會總結',
+            instance=self.instance
+        )
+        try:
+            self.assertEqual(
+                cjk_section.slug,
+                'jing-mao-guo-shi-hui-yi-quan-guo-da-hui-zong-jie'
+            )
+        finally:
+            cjk_section.delete()


### PR DESCRIPTION
At the moment, if you create a speaker or section with an entirely CJK
name (as @clkao has done in an example instance for Taiwan) this is
slugified to the empty string, which then breaks any view that tries to
reverse() to get the URL.

The slugify function that is used is picked by the
mysociety-django-sluggable package.  This can use whatever slugify
function you specify with the SLUGGABLE_SLUGIFY_FUNCTION setting.

For sayit.mysociety.org we weren't specifying one of these so we were
relying on the default which is:
- If unidecode is installed:
  
   lambda s: unidecode(s).replace(' ', '-')
  
  This copes with the Mandarin names (converting to Pinyin, as I
  understand it) but it doesn't downcase, collapse whitespace, etc.
- Otherwise, if pytils is installed, slugify from pytils.translit is
  used.  This doesn't cope with CJK characters, however - it still
  slugifies our test case to the empty string.
- Otherwise, it tries to use django.template.defaultfilters.slugify.
  This also fails with an all-CJK name.

So, this commit sets SLUGGABLE_SLUGIFY_FUNCTION to the slugify function
from the python-slugify package, which copes well with the cases I've
tried.  The other alternative is the awesome-slugify package, but that
doesn't downcase by default so I've gone for python-slugify instead.

The question that bothers me is whether this commit is in the right
package - it would probably be better to change
mysociety-django-sluggable's default to check for the existence of
python-slugify in preference to the other slugify functions, and then
change the setup.py of the sayit application to make sure that
python-slugify is installed. This would mean that the more useful
slugify function would be used by default for anyone using the sayit
application.  However, in the interests of getting a quick fix done, so
that @clkao can continue working on http://sayit.mysociety.org while the
core SayIt developers are away, this seems like a reasonable step.

Fixes https://github.com/mysociety/sayit/issues/360
