### PR TITLE
Typo correction

### DIFF
--- a/sayit_mysociety_org/locale/en/LC_MESSAGES/django.po
+++ b/sayit_mysociety_org/locale/en/LC_MESSAGES/django.po
@@ -618,7 +618,7 @@ msgstr ""
 #: templates/instances/index.html:44
 msgid ""
 "Unlike crusty old PDFs, SayIt works beautifully on every device from a phone "
-"to a tablet to a desktop. And it’s acccessible for screenreaders and "
+"to a tablet to a desktop. And it’s accessible for screenreaders and "
 "assistive devices."
 msgstr ""
 

--- a/sayit_mysociety_org/locale/es/LC_MESSAGES/django.po
+++ b/sayit_mysociety_org/locale/es/LC_MESSAGES/django.po
@@ -768,12 +768,12 @@ msgstr ""
 #: templates/instances/index.html:44
 msgid ""
 "Unlike crusty old PDFs, SayIt works beautifully on every device from a phone "
-"to a tablet to a desktop. And it’s acccessible for screenreaders and "
+"to a tablet to a desktop. And it’s accessible for screenreaders and "
 "assistive devices."
 msgstr ""
 "A diferencia de los viejos archivos PDF, SayIt funciona de maravilla en "
 "todos los dispositivos desde un teléfono a una tableta a un PC escritorio. Y "
-"es acccessible para los lectores de pantalla y los dispositivos de "
+"es accessible para los lectores de pantalla y los dispositivos de "
 "asistencia."
 
 #: templates/instances/index.html:45

--- a/sayit_mysociety_org/locale/he/LC_MESSAGES/django.po
+++ b/sayit_mysociety_org/locale/he/LC_MESSAGES/django.po
@@ -729,7 +729,7 @@ msgstr ""
 #: templates/instances/index.html:44
 msgid ""
 "Unlike crusty old PDFs, SayIt works beautifully on every device from a phone "
-"to a tablet to a desktop. And it’s acccessible for screenreaders and "
+"to a tablet to a desktop. And it’s accessible for screenreaders and "
 "assistive devices."
 msgstr ""
 "שלא כמו קבצי PDF ישנים וקשים, SayIt עובדת נפלא על כל מכשיר, מטלפון נייד, דרך "

--- a/sayit_mysociety_org/locale/hu_HU/LC_MESSAGES/django.po
+++ b/sayit_mysociety_org/locale/hu_HU/LC_MESSAGES/django.po
@@ -620,7 +620,7 @@ msgstr ""
 #: templates/instances/index.html:44
 msgid ""
 "Unlike crusty old PDFs, SayIt works beautifully on every device from a phone "
-"to a tablet to a desktop. And it’s acccessible for screenreaders and "
+"to a tablet to a desktop. And it’s accessible for screenreaders and "
 "assistive devices."
 msgstr ""
 

--- a/sayit_mysociety_org/locale/zh_TW/LC_MESSAGES/django.po
+++ b/sayit_mysociety_org/locale/zh_TW/LC_MESSAGES/django.po
@@ -702,7 +702,7 @@ msgstr ""
 #: templates/instances/index.html:44
 msgid ""
 "Unlike crusty old PDFs, SayIt works beautifully on every device from a phone "
-"to a tablet to a desktop. And it’s acccessible for screenreaders and "
+"to a tablet to a desktop. And it’s accessible for screenreaders and "
 "assistive devices."
 msgstr ""
 "不像惱人的PDF檔案，從手機到桌機，SayIt在任何平台上都能完美呈現，而且它對輔　"

--- a/sayit_mysociety_org/templates/instances/index.html
+++ b/sayit_mysociety_org/templates/instances/index.html
@@ -41,7 +41,7 @@
       <div class="large-6 columns">
         <h2>{% trans 'For councils and organisations that hold public&nbsp;meetings' %}</h2>
         <p>{% trans 'Still publishing meeting transcripts on PDFs? SayIt makes it easier for your readers to find the parts that really interest them.' %}</p>
-        <p>{% trans 'Unlike crusty old PDFs, SayIt works beautifully on every device from a phone to a tablet to a desktop. And it’s acccessible for screenreaders and assistive devices.' %}</p>
+        <p>{% trans 'Unlike crusty old PDFs, SayIt works beautifully on every device from a phone to a tablet to a desktop. And it’s accessible for screenreaders and assistive devices.' %}</p>
         <p class="example">{% trans 'See an example:' %} <a href="http://leveson.sayit.mysociety.org/">{% trans 'The Leveson Inquiry transcripts' %}</a></p>
       </div>
       <div class="large-6 columns">


### PR DESCRIPTION
A user spotted that we'd spelled 'accessible' as 'acccessible'.

I don't know if it was necessary to change the spelling of the English on the translation files (although in fact the Spanish translation had, bizarrely, replicated the typo) but well, I have anyway.